### PR TITLE
Fix display of dataset image colors and resize

### DIFF
--- a/run_dataset.py
+++ b/run_dataset.py
@@ -15,11 +15,12 @@ smoothed_angle = 0
 
 i = 10000
 while(cv2.waitKey(10) != ord('q')):
-    image = scipy.misc.imresize(scipy.misc.imread("driving_dataset/" + str(i) + ".jpg")[-150:], [66, 200]) / 255.0
+    full_image = scipy.misc.imread("driving_dataset/" + str(i) + ".jpg", mode="RGB")
+    image = scipy.misc.imresize(full_image[-150:], [66, 200]) / 255.0
     degrees = model.y.eval(feed_dict={model.x: [image], model.keep_prob: 1.0})[0][0] * 180.0 / scipy.pi
     call("clear")
     print("Predicted steering angle: " + str(degrees) + " degrees")
-    cv2.imshow("frame", image)
+    cv2.imshow("frame", cv2.cvtColor(full_image, cv2.COLOR_RGB2BGR))
     #make smooth angle transitions by turning the steering wheel based on the difference of the current angle
     #and the predicted angle
     smoothed_angle += 0.2 * pow(abs((degrees - smoothed_angle)), 2.0 / 3.0) * (degrees - smoothed_angle) / abs(degrees - smoothed_angle)


### PR DESCRIPTION
Fixes #5 temporarily. Matplotlib takes in BGR while `scipy.misc.imread` gives RGB. Shows larger original image for context. 

![image](https://cloud.githubusercontent.com/assets/3528340/19019923/a546151e-8866-11e6-849a-c805ec9bbca3.png)
